### PR TITLE
Fix for crystal 0.36 compiler error.

### DIFF
--- a/src/net_sample/ping/icmp.cr
+++ b/src/net_sample/ping/icmp.cr
@@ -65,7 +65,7 @@ module NetSample::Ping
       @code = 0u8
       @checksum = 0u16
 
-      abstract def data(io)
+      abstract def data(io : IO)
 
       def data : Bytes
         io = IO::Memory.new(1500)


### PR DESCRIPTION
A minor change to fix the following error
```
In lib/net_sample/src/net_sample/ping/icmp.cr:130:5

 130 | class EchoRequest < EchoData
       ^
Error: abstract `def NetSample::Ping::ICMP::Data#data(io)` must be implemented by NetSample::Ping::ICMP::EchoRequest
```